### PR TITLE
fix: use BTP_FROM instead of ETH_FROM 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,9 @@ deploy-anvil:
 
 deploy:
 	@eval $$(curl -H "x-auth-token: $${BPT_SERVICE_TOKEN}" -s $${BTP_CLUSTER_MANAGER_URL}/ide/foundry/$${BTP_SCS_ID}/env | sed 's/^/export /'); \
-	if [ -z "$${ETH_FROM}" ]; then \
+	if [ -z "$${BTP_FROM}" ]; then \
+		echo "\033[1;33mWARNING: No keys are activated on the node, falling back to interactive mode...\033[0m"; \
+		echo ""; \
 		if [ -z "$${BTP_GAS_PRICE}" ]; then \
 			forge create ./src/Counter.sol:Counter $${EXTRA_ARGS} --rpc-url $${BTP_RPC_URL} --interactive | tee deployment.txt; \
 		else \
@@ -36,9 +38,9 @@ deploy:
 		fi; \
 	else \
 		if [ -z "$${BTP_GAS_PRICE}" ]; then \
-			forge create ./src/Counter.sol:Counter $${EXTRA_ARGS} --rpc-url $${BTP_RPC_URL} --unlocked | tee deployment.txt; \
+			forge create ./src/Counter.sol:Counter $${EXTRA_ARGS} --rpc-url $${BTP_RPC_URL} --unlocked --from $${BTP_FROM} | tee deployment.txt; \
 		else \
-			forge create ./src/Counter.sol:Counter $${EXTRA_ARGS} --rpc-url $${BTP_RPC_URL} --unlocked --gas-price $${BTP_GAS_PRICE} | tee deployment.txt; \
+			forge create ./src/Counter.sol:Counter $${EXTRA_ARGS} --rpc-url $${BTP_RPC_URL} --unlocked --from $${BTP_FROM} --gas-price $${BTP_GAS_PRICE} | tee deployment.txt; \
 		fi; \
 	fi
 
@@ -55,7 +57,7 @@ script:
 		exit 1; \
 	fi
 	@eval $$(curl -H "x-auth-token: $${BPT_SERVICE_TOKEN}" -s $${BTP_CLUSTER_MANAGER_URL}/ide/foundry/$${BTP_SCS_ID}/env | sed 's/^/export /')
-	@if [ -z "${ETH_FROM}" ]; then \
+	@if [ -z "${BTP_FROM}" ]; then \
 		echo "\033[1;33mWARNING: No keys are activated on the node, falling back to interactive mode...\033[0m"; \
 		echo ""; \
 		@DEPLOYED_ADDRESS=$$(grep "Deployed to:" deployment.txt | awk '{print $$3}') forge script script/Counter.s.sol:CounterScript ${EXTRA_ARGS} --rpc-url ${BTP_RPC_URL} -i=1; \

--- a/Makefile
+++ b/Makefile
@@ -27,18 +27,18 @@ deploy-anvil:
 	@forge create ./src/Counter.sol:Counter --rpc-url anvil --interactive | tee deployment-anvil.txt
 
 deploy:
-	@eval $$(curl -H "x-auth-token: $${BPT_SERVICE_TOKEN}" -s $${BTP_CLUSTER_MANAGER_URL}/ide/foundry/$${BTP_SCS_ID}/env | sed 's/^/export /')
-	@if [ -z "${ETH_FROM}" ]; then \
-		if [ -z "${BTP_GAS_PRICE}" ]; then \
-			forge create ./src/Counter.sol:Counter ${EXTRA_ARGS} --rpc-url ${BTP_RPC_URL} --interactive | tee deployment.txt; \
+	@eval $$(curl -H "x-auth-token: $${BPT_SERVICE_TOKEN}" -s $${BTP_CLUSTER_MANAGER_URL}/ide/foundry/$${BTP_SCS_ID}/env | sed 's/^/export /'); \
+	if [ -z "$${ETH_FROM}" ]; then \
+		if [ -z "$${BTP_GAS_PRICE}" ]; then \
+			forge create ./src/Counter.sol:Counter $${EXTRA_ARGS} --rpc-url $${BTP_RPC_URL} --interactive | tee deployment.txt; \
 		else \
-			forge create ./src/Counter.sol:Counter ${EXTRA_ARGS} --rpc-url ${BTP_RPC_URL} --interactive --gas-price ${BTP_GAS_PRICE} | tee deployment.txt; \
+			forge create ./src/Counter.sol:Counter $${EXTRA_ARGS} --rpc-url $${BTP_RPC_URL} --interactive --gas-price $${BTP_GAS_PRICE} | tee deployment.txt; \
 		fi; \
 	else \
-		if [ -z "${BTP_GAS_PRICE}" ]; then \
-			forge create ./src/Counter.sol:Counter ${EXTRA_ARGS} --rpc-url ${BTP_RPC_URL} --unlocked | tee deployment.txt; \
+		if [ -z "$${BTP_GAS_PRICE}" ]; then \
+			forge create ./src/Counter.sol:Counter $${EXTRA_ARGS} --rpc-url $${BTP_RPC_URL} --unlocked | tee deployment.txt; \
 		else \
-			forge create ./src/Counter.sol:Counter ${EXTRA_ARGS} --rpc-url ${BTP_RPC_URL} --unlocked --gas-price ${BTP_GAS_PRICE} | tee deployment.txt; \
+			forge create ./src/Counter.sol:Counter $${EXTRA_ARGS} --rpc-url $${BTP_RPC_URL} --unlocked --gas-price $${BTP_GAS_PRICE} | tee deployment.txt; \
 		fi; \
 	fi
 

--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ deploy-anvil:
 	@forge create ./src/Counter.sol:Counter --rpc-url anvil --interactive | tee deployment-anvil.txt
 
 deploy:
-	@eval $$(curl -H "x-auth-token: $${BPT_SERVICE_TOKEN}" -s $${BTP_CLUSTER_MANAGER_URL}/ide/foundry/$${BTP_SCS_ID}/env | sed 's/^/export /'); \
+	@eval $$(curl -H "x-auth-token: $${BTP_SERVICE_TOKEN}" -s $${BTP_CLUSTER_MANAGER_URL}/ide/foundry/$${BTP_SCS_ID}/env | sed 's/^/export /'); \
 	if [ -z "$${BTP_FROM}" ]; then \
 		echo "\033[1;33mWARNING: No keys are activated on the node, falling back to interactive mode...\033[0m"; \
 		echo ""; \
@@ -56,13 +56,13 @@ script:
 		echo "\033[1;31mERROR: Contract was not deployed or the deployment-anvil.txt went missing.\033[0m"; \
 		exit 1; \
 	fi
-	@eval $$(curl -H "x-auth-token: $${BPT_SERVICE_TOKEN}" -s $${BTP_CLUSTER_MANAGER_URL}/ide/foundry/$${BTP_SCS_ID}/env | sed 's/^/export /')
-	@if [ -z "${BTP_FROM}" ]; then \
+	@eval $$(curl -H "x-auth-token: $${BTP_SERVICE_TOKEN}" -s $${BTP_CLUSTER_MANAGER_URL}/ide/foundry/$${BTP_SCS_ID}/env | sed 's/^/export /'); \
+	if [ -z "${BTP_FROM}" ]; then \
 		echo "\033[1;33mWARNING: No keys are activated on the node, falling back to interactive mode...\033[0m"; \
 		echo ""; \
 		@DEPLOYED_ADDRESS=$$(grep "Deployed to:" deployment.txt | awk '{print $$3}') forge script script/Counter.s.sol:CounterScript ${EXTRA_ARGS} --rpc-url ${BTP_RPC_URL} -i=1; \
 	else \
-		@DEPLOYED_ADDRESS=$$(grep "Deployed to:" deployment.txt | awk '{print $$3}') forge script script/Counter.s.sol:CounterScript ${EXTRA_ARGS} --rpc-url ${BTP_RPC_URL} --unlocked; \
+		@DEPLOYED_ADDRESS=$$(grep "Deployed to:" deployment.txt | awk '{print $$3}') forge script script/Counter.s.sol:CounterScript ${EXTRA_ARGS} --rpc-url ${BTP_RPC_URL} --unlocked --froms ${BTP_FROM}; \
 	fi
 
 cast:
@@ -81,8 +81,8 @@ subgraph:
 	@cd subgraph && yq e '.features = ["nonFatalErrors", "fullTextSearch", "ipfsOnEthereumContracts"]' -i generated/solidity-token-erc20.subgraph.yaml
 	@cd subgraph && pnpm graph codegen generated/solidity-token-erc20.subgraph.yaml
 	@cd subgraph && pnpm graph build generated/solidity-token-erc20.subgraph.yaml
-	@eval $$(curl -H "x-auth-token: $${BPT_SERVICE_TOKEN}" -s $${BTP_CLUSTER_MANAGER_URL}/ide/foundry/$${BTP_SCS_ID}/env | sed 's/^/export /')
-	@if [ "$${BTP_MIDDLEWARE}" == "" ]; then \
+	@eval $$(curl -H "x-auth-token: $${BTP_SERVICE_TOKEN}" -s $${BTP_CLUSTER_MANAGER_URL}/ide/foundry/$${BTP_SCS_ID}/env | sed 's/^/export /'); \
+	if [ "$${BTP_MIDDLEWARE}" == "" ]; then \
 		echo "You have not launched a graph middleware for this smart contract set, aborting..."; \
 		exit 1; \
 	else \


### PR DESCRIPTION
The interactive mode was being used even when an ETH_FROM was being returned from the cluster manager. This is because we have the if statement and exporting the envs in separate commands in the Makefile, which are executed in separate terminal subshells.  