### PR TITLE
fix: remove subgraph 

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -67,12 +67,6 @@
       "problemMatcher": []
     },
     {
-      "label": "subgraph",
-      "type": "shell",
-      "command": "make subgraph",
-      "problemMatcher": []
-    },
-    {
       "label": "help",
       "type": "shell",
       "command": "make help",

--- a/Makefile
+++ b/Makefile
@@ -69,28 +69,6 @@ cast:
 	@echo "Interacting with EVM via Cast..."
 	@cast $(SUBCOMMAND)
 
-subgraph:
-	@echo "Deploying the subgraph..."
-	@rm -Rf subgraph/subgraph.config.json
-	@DEPLOYED_ADDRESS=$$(grep "Deployed to:" deployment.txt | awk '{print $$3}') yq e -p=json -o=json '.datasources[0].address = env(DEPLOYED_ADDRESS) | .chain = env(BTP_NETWORK_NAME)' subgraph/subgraph.config.template.json > subgraph/subgraph.config.json
-	@cd subgraph && pnpm graph-compiler --config subgraph.config.json --include node_modules/@openzeppelin/subgraphs/src/datasources subgraph/datasources --export-schema --export-subgraph
-	@cd subgraph && yq e '.specVersion = "0.0.4"' -i generated/solidity-token-erc20.subgraph.yaml
-	@cd subgraph && yq e '.description = "Solidity Token ERC20"' -i generated/solidity-token-erc20.subgraph.yaml
-	@cd subgraph && yq e '.repository = "https://github.com/settlemint/solidity-token-erc20"' -i generated/solidity-token-erc20.subgraph.yaml
-	@cd subgraph && yq e '.indexerHints.prune = "auto"' -i generated/solidity-token-erc20.subgraph.yaml
-	@cd subgraph && yq e '.features = ["nonFatalErrors", "fullTextSearch", "ipfsOnEthereumContracts"]' -i generated/solidity-token-erc20.subgraph.yaml
-	@cd subgraph && pnpm graph codegen generated/solidity-token-erc20.subgraph.yaml
-	@cd subgraph && pnpm graph build generated/solidity-token-erc20.subgraph.yaml
-	@eval $$(curl -H "x-auth-token: $${BTP_SERVICE_TOKEN}" -s $${BTP_CLUSTER_MANAGER_URL}/ide/foundry/$${BTP_SCS_ID}/env | sed 's/^/export /'); \
-	if [ "$${BTP_MIDDLEWARE}" == "" ]; then \
-		echo "You have not launched a graph middleware for this smart contract set, aborting..."; \
-		exit 1; \
-	else \
-		cd subgraph; \
-		pnpm graph create --node $${BTP_MIDDLEWARE} $${BTP_SCS_NAME}; \
-		pnpm graph deploy --version-label v1.0.$$(date +%s) --node $${BTP_MIDDLEWARE} --ipfs $${BTP_IPFS}/api/v0 $${BTP_SCS_NAME} generated/solidity-token-erc20.subgraph.yaml; \
-	fi
-
 help:
 	@echo "Forge help..."
 	@forge --help


### PR DESCRIPTION
We don't have a subgraph for solidity empty, so the subgraph tasks fail with: 

```
 Executing task: make subgraph 

Deploying the subgraph...
/bin/sh: 1: cannot create subgraph/subgraph.config.json: Directory nonexistent
make: *** [Makefile:75: subgraph] Error 2

 *  The terminal process "/usr/bin/bash '-c', 'make subgraph'" failed to launch (exit code: 2). 
 *  Terminal will be reused by tasks, press any key to close it. 
```

<img width="2032" alt="image" src="https://github.com/settlemint/solidity-empty/assets/62167899/b1078364-a2a0-4bfe-8968-6332ff9363bc">

